### PR TITLE
add missing parentheses

### DIFF
--- a/src/services/ChallengeServices.ts
+++ b/src/services/ChallengeServices.ts
@@ -5,7 +5,7 @@ const prisma = new PrismaClient();
 const getTodaysChallenge = async () => {
   const date = new Date();
   const day_of_year = Math.floor(
-    date.getTime() - new Date(date.getFullYear(), 0, 0).getTime() / 86400000
+    (date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000
   );
 
   // Calculate a desired index based on the current day of the year and the total number of challenges


### PR DESCRIPTION
The problem causing inconsistent challenge selection was a set of parentheses that was missing in a calculation. This PR should solve the issue.